### PR TITLE
statically linked calico

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,25 +7,22 @@ platform:
 
 steps:
 - name: build
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - sleep 20
-  - TAG=${DRONE_TAG} make
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG}
 
-- name: push
-  image: rancher/hardened-build-base:v1.14.2-amd64
+- name: publish
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - TAG=${DRONE_TAG} make image-push
+  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
   environment:
     DOCKER_USERNAME:
       from_secret: docker_username
@@ -36,26 +33,12 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.14.2-amd64
+  image: rancher/hardened-build-base:v1.13.15b4
   volumes:
   - name: dockersock
     path: /var/run
   commands:
-  - TAG=${DRONE_TAG} make image-scan
-  when:
-    event:
-    - tag
-
-- name: manifest
-  image: rancher/hardened-build-base:v1.14.2-amd64
-  volumes:
-  - name: dockersock
-    path: /var/run
-  commands:
-  - TAG=${DRONE_TAG} make image-manifest
-  when:
-    event:
-    - tag
+  - make DRONE_TAG=${DRONE_TAG} image-scan
 
 services:
 - name: docker
@@ -66,5 +49,5 @@ services:
     path: /var/run
 
 volumes:
-  - name: dockersock
-    temp: {}
+- name: dockersock
+  temp: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,78 +1,166 @@
+ARG ARCH="amd64"
+ARG TAG="v3.13.3"
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.14.2-amd64
-ARG RUNIT_VER=2.1.2
-ARG BIRD_IMAGE=calico/bird:v0.3.3-160-g7df7218c-amd64
-
+ARG GO_IMAGE=rancher/hardened-build-base:v1.15.2b5
 FROM ${UBI_IMAGE} as ubi
-
 FROM ${GO_IMAGE} as builder
-ARG TAG="" 
+# setup required packages
+RUN set -x \
+ && apk --no-cache add \
+    bash \
+    curl \
+    file \
+    gcc \
+    git \
+    linux-headers \
+    make
+
+### BEGIN K3S XTABLES ###
+FROM builder AS k3s_xtables
+ARG ARCH
 ARG K3S_ROOT_VERSION=v0.6.0-rc3
-RUN apt update                                      && \ 
-    apt upgrade -y                                  && \ 
-    apt install -y apt-transport-https ca-certificates \
-    software-properties-common git                     \
-    curl bash
+ADD https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-${ARCH}.tar /opt/xtables/k3s-root-xtables.tar
+RUN tar xvf /opt/xtables/k3s-root-xtables.tar -C /opt/xtables
+### END K3S XTABLES #####
 
-RUN mkdir -p /tmp/xtables && \
-    curl -L https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-amd64.tar -o /tmp/xtables/k3s-root-xtables.tar && \
-    tar -C /tmp/xtables -xvf /tmp/xtables/k3s-root-xtables.tar
+FROM calico/bpftool:v5.3-${ARCH} AS calico_bpftool
+FROM calico/bird:v0.3.3-160-g7df7218c-${ARCH} AS calico_bird
 
-RUN git clone --depth=1 https://github.com/projectcalico/calicoctl.git
-RUN cd /go/calicoctl                                                                                                                                 && \
-    git fetch --all --tags --prune                                                                                                                   && \
-    git checkout tags/${TAG} -b ${TAG}                                                                                                               && \
-    CGO_ENABLED=1 go build -v -o bin/calicoctl -ldflags "-X github.com/projectcalico/calicoctl/calicoctl/commands.VERSION=$(git rev-parse --short HEAD) \
-    -X github.com/projectcalico/calicoctl/calicoctl/commands.GIT_REVISION=$(git rev-parse --short HEAD) -s -w" "./calicoctl/calicoctl.go"            && \
-    cd /go
+### BEGIN CALICOCTL ###
+FROM builder AS calico_ctl
+ARG TAG
+RUN git clone --depth=1 https://github.com/projectcalico/calicoctl.git $GOPATH/src/github.com/projectcalico/calicoctl
+WORKDIR $GOPATH/src/github.com/projectcalico/calicoctl
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${TAG} -b ${TAG}
+RUN GO_LDFLAGS="-linkmode=external \
+    -X github.com/projectcalico/calicoctl/calicoctl/commands.VERSION=${TAG} \
+    -X github.com/projectcalico/calicoctl/calicoctl/commands.GIT_REVISION=$(git rev-parse --short HEAD) \
+    " go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/calicoctl ./calicoctl/calicoctl.go
+RUN go-assert-static.sh bin/*
+RUN go-assert-boring.sh bin/*
+RUN install -s bin/* /usr/local/bin
+RUN calicoctl --version
+### END CALICOCTL #####
 
-RUN git clone --depth=1 https://github.com/projectcalico/cni-plugin.git
-RUN cd /go/cni-plugin                                                                                                             && \
-    git fetch --all --tags --prune                                                                                                && \
-    git checkout tags/${TAG} -b ${TAG}                                                                                            && \
-    mkdir bin                                                                                                                     && \
-    CGO_ENABLED=1 go build -v -o bin/calico -ldflags "-X main.VERSION=$(git rev-parse --short HEAD) -s -w" ./cmd/calico           && \
-    CGO_ENABLED=1 go build -v -o bin/calico-ipam -ldflags "-X main.VERSION=$(git rev-parse --short HEAD) -s -w" ./cmd/calico-ipam && \
-    make fetch-cni-bins                                                                                                           && \
-    cd /go
 
-RUN git clone --depth=1 https://github.com/projectcalico/node.git
-RUN cd /go/node                                                                                                                                           && \
-    git fetch --all --tags --prune                                                                                                                        && \
-    git checkout tags/${TAG} -b ${TAG}                                                                                                                    && \
-    mkdir -p dist/bin                                                                                                                                     && \
-    CGO_ENABLED=1 go build -v -o dist/bin/calico-node -ldflags "-X github.com/projectcalico/node/pkg/startup.VERSION=$(git describe --tags --dirty --always) \
-    -X github.com/projectcalico/node/buildinfo.GitVersion=$(git describe --tags --dirty --always)                                                            \
-    -X github.com/projectcalico/node/buildinfo.BuildDate=$(date -u +'%FT%T%z')                                                                               \
-    -X github.com/projectcalico/node/buildinfo.GitRevision=$(git rev-parse HEAD) -w -s -extldflags \"-static\"" ./cmd/calico-node/main.go                                               && \
-    cd /go
+### BEGIN CALICO CNI ###
+FROM builder AS calico_cni
+ARG TAG
+RUN git clone --depth=1 https://github.com/projectcalico/cni-plugin.git $GOPATH/src/github.com/projectcalico/cni-plugin
+WORKDIR $GOPATH/src/github.com/projectcalico/cni-plugin
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${TAG} -b ${TAG}
+ENV GO_LDFLAGS="-linkmode=external -X main.VERSION=${TAG}"
+RUN go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/calico ./cmd/calico
+RUN go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/calico-ipam ./cmd/calico-ipam
+RUN go-assert-static.sh bin/*
+RUN go-assert-boring.sh bin/*
+RUN mkdir -vp /opt/cni/bin
+RUN install -s bin/* /opt/cni/bin/
+RUN install -m 0755 k8s-install/scripts/install-cni.sh /opt/cni/install-cni.sh
+RUN install -m 0644 k8s-install/scripts/calico.conf.default /opt/cni/calico.conf.default
+### END CALICO CNI #####
 
-RUN git clone --depth=1 https://github.com/projectcalico/pod2daemon.git
-RUN cd /go/pod2daemon                  && \
-    git fetch --all --tags --prune     && \
-    git checkout tags/${TAG} -b ${TAG} && \
-    mkdir -p bin/flexvol-amd64         && \
-    CGO_ENABLED=1 go build -v -o bin/flexvol-amd64 flexvol/flexvoldriver.go
 
-FROM calico/bpftool:v5.3-amd64 as bpftool
-FROM ${BIRD_IMAGE} as bird
+### BEGIN CALICO NODE ###
+FROM builder AS calico_node
+ARG TAG
+RUN git clone --depth=1 https://github.com/projectcalico/node.git $GOPATH/src/github.com/projectcalico/node
+WORKDIR $GOPATH/src/github.com/projectcalico/node
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${TAG} -b ${TAG}
+RUN GO_LDFLAGS="-linkmode=external \
+    -X github.com/projectcalico/node/pkg/startup.VERSION=${TAG} \
+    -X github.com/projectcalico/node/buildinfo.GitRevision=$(git rev-parse HEAD) \
+    -X github.com/projectcalico/node/buildinfo.GitVersion=$(git describe --tags --always) \
+    -X github.com/projectcalico/node/buildinfo.BuildDate=$(date -u +%FT%T%z) \
+    " go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/calico-node ./cmd/calico-node
+RUN go-assert-static.sh bin/*
+RUN go-assert-boring.sh bin/*
+RUN install -s bin/* /usr/local/bin
+### END CALICO NODE #####
 
-# Use this build stage to build runit.
+
+### BEGIN CALICO POD2DAEMON ###
+FROM builder AS calico_pod2daemon
+ARG TAG
+RUN git clone --depth=1 https://github.com/projectcalico/pod2daemon.git $GOPATH/src/github.com/projectcalico/pod2daemon
+WORKDIR $GOPATH/src/github.com/projectcalico/pod2daemon
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${TAG} -b ${TAG}
+ENV GO_LDFLAGS="-linkmode=external"
+RUN go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/flexvoldriver ./flexvol
+RUN go-assert-static.sh bin/*
+RUN install -m 0755 flexvol/docker/flexvol.sh /usr/local/bin/
+RUN install -D -s bin/flexvoldriver /usr/local/bin/flexvol/flexvoldriver
+### END CALICO POD2DAEMON #####
+
+
+### BEGIN CNI PLUGINS ###
+FROM builder AS cni_plugins
+ARG TAG
+ARG CNI_PLUGINS_VERSION="v0.8.7"
+RUN git clone --depth=1 https://github.com/containernetworking/plugins.git $GOPATH/src/github.com/containernetworking/plugins
+WORKDIR $GOPATH/src/github.com/containernetworking/plugins
+RUN git fetch --all --tags --prune
+RUN git checkout tags/${CNI_PLUGINS_VERSION} -b ${CNI_PLUGINS_VERSION}
+RUN sh -ex ./build_linux.sh -v \
+    -gcflags=-trimpath=/go/src \
+    -ldflags " \
+        -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${CNI_PLUGINS_VERSION} \
+        -linkmode=external -extldflags \"-static -Wl,--fatal-warnings\" \
+    "
+RUN go-assert-static.sh bin/*
+RUN go-assert-boring.sh \
+    bin/bandwidth \
+    bin/bridge \
+    bin/dhcp \
+    bin/firewall \
+    bin/host-device \
+    bin/host-local \
+    bin/ipvlan \
+    bin/macvlan \
+    bin/portmap \
+    bin/ptp \
+    bin/vlan
+# install (with strip) to /opt/cni/bin
+RUN mkdir -vp /opt/cni/bin
+RUN install -D -s bin/* /opt/cni/bin
+### END CNI PLUGINS #####
+
+
+### BEGIN RUNIT ###
 # We need to build runit because there aren't any rpms for it in CentOS or ubi repositories.
-FROM centos:7 as centos
-ARG RUNIT_VER
-
+FROM centos:7 AS runit
+ARG RUNIT_VER=2.1.2
 # Install build dependencies and security updates.
 RUN yum install -y rpm-build yum-utils make && \
     yum install -y wget glibc-static gcc    && \
     yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
-
 # runit is not available in ubi or CentOS repos so build it.
-RUN wget -P /tmp http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz && \
-    gunzip /tmp/runit-${RUNIT_VER}.tar.gz                           && \
-    tar -xpf /tmp/runit-${RUNIT_VER}.tar -C /tmp                    && \
-    cd /tmp/admin/runit-${RUNIT_VER}/                               && \
-    package/install
+ADD http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz /tmp/runit.tar.gz
+WORKDIR /opt/local
+RUN tar xzf /tmp/runit.tar.gz --strip-components=2 -C .
+RUN ./package/install
+### END RUNIT #####
+
+
+# gather all of the disparate calico bits into a rootfs overlay
+FROM scratch AS calico_rootfs_overlay
+COPY --from=calico_node /go/src/github.com/projectcalico/node/filesystem/etc/       /etc/
+COPY --from=calico_node /go/src/github.com/projectcalico/node/filesystem/licenses/  /licenses/
+COPY --from=calico_node /go/src/github.com/projectcalico/node/filesystem/sbin/      /usr/sbin/
+COPY --from=calico_node /usr/local/bin/      	/usr/bin/
+COPY --from=calico_ctl /usr/local/bin/calicoctl /calicoctl
+COPY --from=calico_bird /bird*                  /usr/bin/
+COPY --from=calico_bpftool /bpftool             /usr/sbin/
+COPY --from=calico_pod2daemon /usr/local/bin/   /usr/local/bin/
+COPY --from=calico_cni /opt/cni/                /opt/cni/
+COPY --from=cni_plugins /opt/cni/               /opt/cni/
+COPY --from=k3s_xtables /opt/xtables/bin/       /usr/sbin/
+COPY --from=runit /opt/local/command/           /usr/sbin/
+
 
 FROM ubi
 RUN microdnf update -y                         && \
@@ -82,39 +170,10 @@ RUN microdnf update -y                         && \
     libnetfilter_queue ipset kmod iputils iproute \
     procps net-tools conntrack-tools which     && \
     rm -rf /var/cache/yum
-
-COPY --from=builder /tmp/xtables/bin/* /usr/sbin/
-
-ARG GIT_VERSION
-ARG RUNIT_VER
-
-# Copy in runit binaries
-COPY --from=centos /tmp/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
-
-# Copy our bird binaries in
-COPY --from=bird /bird* /bin/
-
-# Copy in the filesystem - this contains felix, calico-bgp-daemon, licenses, etc...
-COPY --from=builder /go/node/filesystem/ /
-
-# Add symlink to modprobe where iptables expects it to be.
-# This has to come after copying over filesystem/, since that may overwrite /sbin depending on the base image.
-RUN ln -s /usr/sbin/modprobe /sbin/modprobe
-
-RUN mkdir -p /opt/cni
+COPY --from=calico_rootfs_overlay / /
 ENV PATH=$PATH:/opt/cni/bin
-
-COPY --from=builder /go/calicoctl/bin/calicoctl /calicoctl
-
-COPY --from=builder /go/cni-plugin/bin/calico /opt/cni/bin/calico
-COPY --from=builder /go/cni-plugin/bin/calico-ipam /opt/cni/bin/calico-ipam
-COPY --from=builder /go/cni-plugin/k8s-install/scripts/install-cni.sh /install-cni.sh
-COPY --from=builder /go/cni-plugin/k8s-install/scripts/calico.conf.default /calico.conf.tmp
-COPY --from=builder /go/cni-plugin/bin/amd64 /opt/cni/bin
-
-COPY --from=builder /go/node/dist/bin /bin
-COPY --from=bpftool /bpftool /bin
-
-COPY --from=builder /go/pod2daemon/flexvol/docker/flexvol.sh /usr/local/bin
-COPY --from=builder /go/pod2daemon/bin/flexvol-amd64 /usr/local/bin/flexvol
-
+RUN set -x \
+ && test -e /opt/cni/install-cni.sh \
+ && ln -vs /opt/cni/install-cni.sh /install-cni.sh \
+ && test -e /opt/cni/calico.conf.default \
+ && ln -vs /opt/cni/calico.conf.default /calico.conf.tmp

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,40 @@
 SEVERITIES = HIGH,CRITICAL
 
-.PHONY: all
-all:
-	docker build --build-arg TAG=$(TAG) -t rancher/hardened-calico:$(TAG) .
+ifeq ($(ARCH),)
+ARCH=$(shell go env GOARCH)
+endif
+
+ORG ?= rancher
+TAG ?= v3.13.3
+
+ifneq ($(DRONE_TAG),)
+TAG := $(DRONE_TAG)
+endif
+
+CNI_PLUGINS_VERSION ?= v0.8.7
+
+.PHONY: image-build
+image-build:
+	docker build \
+		--build-arg ARCH=$(ARCH) \
+		--build-arg CNI_PLUGINS_VERSION=$(CNI_PLUGINS_VERSION) \
+		--build-arg TAG=$(TAG) \
+		--tag $(ORG)/hardened-calico:$(TAG) \
+		--tag $(ORG)/hardened-calico:$(TAG)-$(ARCH) \
+	.
 
 .PHONY: image-push
 image-push:
-	docker push rancher/hardened-calico:$(TAG) >> /dev/null
-
-.PHONY: scan
-image-scan:
-	trivy --severity $(SEVERITIES) --no-progress --skip-update --ignore-unfixed rancher/hardened-calico:$(TAG)
+	docker push $(ORG)/hardened-calico:$(TAG)-$(ARCH)
 
 .PHONY: image-manifest
 image-manifest:
-	docker image inspect rancher/hardened-calico:$(TAG)
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create rancher/hardened-calico:$(TAG) \
-		$(shell docker image inspect rancher/hardened-calico:$(TAG) | jq -r '.[] | .RepoDigests[0]')
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
+		$(ORG)/hardened-calico:$(TAG) \
+		$(ORG)/hardened-calico:$(TAG)-$(ARCH)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
+		$(ORG)/hardened-calico:$(TAG)
+
+.PHONY: image-scan
+image-scan:
+	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-calico:$(TAG)


### PR DESCRIPTION
Leverage new alpine-based rancher/hardened-build-base (goboring built on
alpine) while matching the upstream version of go to compile with. Also
assert everything is statically linked and assert presence of goboring
symbols prior to install-with-strip.

Addresses rancher/rke2#335
