### PR TITLE
Update to v3.20.3 and add dualStack support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
-TAG ?= v3.20.2$(BUILD_META)
+TAG ?= v3.20.3$(BUILD_META)
 
 K3S_ROOT_VERSION ?= v0.10.1
 

--- a/dualStack-changes.patch
+++ b/dualStack-changes.patch
@@ -1,0 +1,219 @@
+From a8eab5d86a7e3fe08636aba6d53f9be6d8dd4c4c Mon Sep 17 00:00:00 2001
+From: manuelbuil <mbuil@suse.com>
+Date: Tue, 11 Jan 2022 11:37:19 +0100
+Subject: [PATCH] Dual-stack patch
+
+Signed-off-by: manuelbuil <mbuil@suse.com>
+---
+ internal/pkg/utils/utils.go | 57 +++++++++++++++++++++++++------------
+ pkg/k8s/k8s.go              | 55 +++++++++++++++++++++++++++--------
+ 2 files changed, 82 insertions(+), 30 deletions(-)
+
+diff --git a/internal/pkg/utils/utils.go b/internal/pkg/utils/utils.go
+index faa8720..e87c61e 100644
+--- a/internal/pkg/utils/utils.go
++++ b/internal/pkg/utils/utils.go
+@@ -202,16 +202,18 @@ func DeleteIPAM(conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) er
+ 		// We need to replace "usePodCidr" with a valid, but dummy podCidr string with "host-local" IPAM.
+ 		// host-local IPAM releases the IP by ContainerID, so podCidr isn't really used to release the IP.
+ 		// It just needs a valid CIDR, but it doesn't have to be the CIDR associated with the host.
+-		const dummyPodCidr = "0.0.0.0/0"
++		dummyPodCidrv4 := "0.0.0.0/0"
++		dummyPodCidrv6 := "::/0"
+ 		var stdinData map[string]interface{}
+ 		err := json.Unmarshal(args.StdinData, &stdinData)
+ 		if err != nil {
+ 			return err
+ 		}
+ 
+-		logger.WithField("podCidr", dummyPodCidr).Info("Using a dummy podCidr to release the IP")
+-		getDummyPodCIDR := func() (string, error) {
+-			return dummyPodCidr, nil
++		logger.WithFields(logrus.Fields{"podCidrv4": dummyPodCidrv4,
++			"podCidrv6": dummyPodCidrv6}).Info("Using dummy podCidrs to release the IPs")
++		getDummyPodCIDR := func() (string, string, error) {
++			return dummyPodCidrv4, dummyPodCidrv6, nil
+ 		}
+ 		err = ReplaceHostLocalIPAMPodCIDRs(logger, stdinData, getDummyPodCIDR)
+ 		if err != nil {
+@@ -286,13 +288,13 @@ func DeleteIPAM(conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) er
+ //      }
+ //      ...
+ //    }
+-func ReplaceHostLocalIPAMPodCIDRs(logger *logrus.Entry, stdinData map[string]interface{}, getPodCIDR func() (string, error)) error {
++func ReplaceHostLocalIPAMPodCIDRs(logger *logrus.Entry, stdinData map[string]interface{}, getPodCIDRs func() (string, string, error)) error {
+ 	ipamData, ok := stdinData["ipam"].(map[string]interface{})
+ 	if !ok {
+ 		return fmt.Errorf("failed to parse host-local IPAM data; was expecting a dict, not: %v", stdinData["ipam"])
+ 	}
+ 	// Older versions of host-local IPAM store a single subnet in the top-level IPAM dict.
+-	err := replaceHostLocalIPAMPodCIDR(logger, ipamData, getPodCIDR)
++	err := replaceHostLocalIPAMPodCIDR(logger, ipamData, getPodCIDRs)
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -310,7 +312,7 @@ func ReplaceHostLocalIPAMPodCIDRs(logger *logrus.Entry, stdinData map[string]int
+ 				return fmt.Errorf("failed to parse host-local IPAM range set; was expecting a list, not: %v", rs)
+ 			}
+ 			for _, r := range rs {
+-				err := replaceHostLocalIPAMPodCIDR(logger, r, getPodCIDR)
++				err := replaceHostLocalIPAMPodCIDR(logger, r, getPodCIDRs)
+ 				if err != nil {
+ 					return err
+ 				}
+@@ -320,29 +322,47 @@ func ReplaceHostLocalIPAMPodCIDRs(logger *logrus.Entry, stdinData map[string]int
+ 	return nil
+ }
+ 
+-func replaceHostLocalIPAMPodCIDR(logger *logrus.Entry, rawIpamData interface{}, getPodCidr func() (string, error)) error {
++func replaceHostLocalIPAMPodCIDR(logger *logrus.Entry, rawIpamData interface{}, getPodCidrs func() (string, string, error)) error {
+ 	logrus.WithField("ipamData", rawIpamData).Debug("Examining IPAM data for usePodCidr")
+ 	ipamData, ok := rawIpamData.(map[string]interface{})
+ 	if !ok {
+ 		return fmt.Errorf("failed to parse host-local IPAM data; was expecting a dict, not: %v", rawIpamData)
+ 	}
+ 	subnet, _ := ipamData["subnet"].(string)
++
+ 	if strings.EqualFold(subnet, "usePodCidr") {
+-		logger.Info("Calico CNI fetching podCidr from Kubernetes")
+-		podCidr, err := getPodCidr()
++		ipv4Cidr, _, err := getPodCidrs()
++		if err != nil {
++			logger.Errorf("Failed to getPodCidrs")
++			return err
++		}
++		if ipv4Cidr == "" {
++			return errors.New("usePodCidr found but there is no IPv4 CIDR configured")
++		}
++
++		ipamData["subnet"] = ipv4Cidr
++		subnet = ipv4Cidr
++		logger.Infof("Calico CNI passing podCidr to host-local IPAM: %s", ipv4Cidr)
++
++		// updateHostLocalIPAMDataForOS is only required for Windows and only ipv4 is supported
++		err = updateHostLocalIPAMDataForOS(subnet, ipamData)
+ 		if err != nil {
+-			logger.Info("Failed to getPodCidr")
+ 			return err
+ 		}
+-		logger.WithField("podCidr", podCidr).Info("Fetched podCidr")
+-		ipamData["subnet"] = podCidr
+-		subnet = podCidr
+-		logger.Infof("Calico CNI passing podCidr to host-local IPAM: %s", podCidr)
+ 	}
+ 
+-	err := updateHostLocalIPAMDataForOS(subnet, ipamData)
+-	if err != nil {
+-		return err
++	if strings.EqualFold(subnet, "usePodCidrIPv6") {
++		_, ipv6Cidr, err := getPodCidrs()
++		if err != nil {
++			logger.Errorf("Failed to ipv6 getPodCidrs")
++			return err
++		}
++		if ipv6Cidr == "" {
++			return errors.New("usePodCidrIPv6 found but there is no IPv6 CIDR configured")
++		}
++
++		ipamData["subnet"] = ipv6Cidr
++		logger.Infof("Calico CNI passing podCidrv6 to host-local IPAM: %s", ipv6Cidr)
+ 	}
+ 
+ 	return nil
+@@ -360,6 +380,7 @@ func UpdateHostLocalIPAMDataForWindows(subnet string, ipamData map[string]interf
+ 		return err
+ 	}
+ 	//process only if we have ipv4 subnet
++	//VXLAN networks on Windows do not support dual-stack https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#ipv6-networking
+ 	if ip.To4() != nil {
+ 		//get Expected start and end range for given CIDR
+ 		expStartRange, expEndRange := getIPRanges(ip, ipnet)
+diff --git a/pkg/k8s/k8s.go b/pkg/k8s/k8s.go
+index ca11f90..e4170df 100644
+--- a/pkg/k8s/k8s.go
++++ b/pkg/k8s/k8s.go
+@@ -106,18 +106,24 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
+ 		}
+ 
+ 		// Defer to ReplaceHostLocalIPAMPodCIDRs to swap the "usePodCidr" value out.
+-		var cachedPodCidr string
+-		getRealPodCIDR := func() (string, error) {
+-			if cachedPodCidr == "" {
++		var cachedPodCidrs []string
++		var cachedIpv4Cidr, cachedIpv6Cidr string
++		getRealPodCIDRs := func() (string, string, error) {
++			if len(cachedPodCidrs) == 0 {
+ 				var err error
+-				cachedPodCidr, err = getPodCidr(client, conf, epIDs.Node)
++				var emptyResult string
++				cachedPodCidrs, err = getPodCidrs(client, conf, epIDs.Node)
+ 				if err != nil {
+-					return "", err
++					return emptyResult, emptyResult, err
++				}
++				cachedIpv4Cidr, cachedIpv6Cidr, err = getIPsByFamily(cachedPodCidrs)
++				if err != nil {
++					return emptyResult, emptyResult, err
+ 				}
+ 			}
+-			return cachedPodCidr, nil
++			return cachedIpv4Cidr, cachedIpv6Cidr, nil
+ 		}
+-		err = utils.ReplaceHostLocalIPAMPodCIDRs(logger, stdinData, getRealPodCIDR)
++		err = utils.ReplaceHostLocalIPAMPodCIDRs(logger, stdinData, getRealPodCIDRs)
+ 		if err != nil {
+ 			return nil, err
+ 		}
+@@ -892,7 +898,9 @@ func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (
+ 	return labels, pod.Annotations, ports, profiles, generateName, serviceAccount, nil
+ }
+ 
+-func getPodCidr(client *kubernetes.Clientset, conf types.NetConf, nodename string) (string, error) {
++// getPodCidrs returns the podCidrs included in the node manifest
++func getPodCidrs(client *kubernetes.Clientset, conf types.NetConf, nodename string) ([]string, error) {
++	var emptyString []string
+ 	// Pull the node name out of the config if it's set. Defaults to nodename
+ 	if conf.Kubernetes.NodeName != "" {
+ 		nodename = conf.Kubernetes.NodeName
+@@ -900,11 +908,34 @@ func getPodCidr(client *kubernetes.Clientset, conf types.NetConf, nodename strin
+ 
+ 	node, err := client.CoreV1().Nodes().Get(context.Background(), nodename, metav1.GetOptions{})
+ 	if err != nil {
+-		return "", err
++		return emptyString, err
++	}
++	if len(node.Spec.PodCIDRs) == 0 {
++		return emptyString, fmt.Errorf("no podCidr for node %s", nodename)
++	}
++	return node.Spec.PodCIDRs, nil
++}
++
++// getIPsByFamily returns the IPv4 and IPv6 CIDRs
++func getIPsByFamily(cidrs []string) (string, string, error) {
++	var ipv4Cidr, ipv6Cidr string
++	for _, cidr := range cidrs {
++		_, ipNet, err := cnet.ParseCIDR(cidr)
++		if err != nil {
++			return "", "", err
++		}
++		if ipNet.Version() == 4 {
++			ipv4Cidr = cidr
++		}
++
++		if ipNet.Version() == 6 {
++			ipv6Cidr = cidr
++		}
+ 	}
+ 
+-	if node.Spec.PodCIDR == "" {
+-		return "", fmt.Errorf("no podCidr for node %s", nodename)
++	if (len(cidrs) > 1) && (ipv4Cidr == "" || ipv6Cidr == "") {
++		return "", "", errors.New("ClusterCIDR contains two ranges of the same type")
+ 	}
+-	return node.Spec.PodCIDR, nil
++
++	return ipv4Cidr, ipv6Cidr, nil
+ }
+-- 
+2.26.2
+


### PR DESCRIPTION
Updates to version v3.20.3 of calico and latest on rancher/hardened-build-base

Besides, it cherry picks the PR that enables dual-stack in Canal https://github.com/projectcalico/calico/pull/5313

Issue: https://github.com/rancher/rke2/issues/2342

Signed-off-by: manuelbuil <mbuil@suse.com>