### PR TITLE
Upgrade to v3.21.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 ARG ARCH="amd64"
-ARG TAG="v3.20.3"
+ARG TAG="v3.21.2"
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
 ARG GO_IMAGE=rancher/hardened-build-base:v1.17.3b7
 ARG CNI_IMAGE=rancher/hardened-cni-plugins:v0.9.1-build20211119
+ARG GO_BORING=goboring/golang:1.16.7b7
 
 FROM ${UBI_IMAGE} as ubi
 FROM ${CNI_IMAGE} as cni
@@ -18,6 +19,14 @@ RUN set -x \
     linux-headers \
     make \
     patch
+
+# Image for projectcalico/node. Because of libbpf-dev and libelf-dev dependencies we can't use Alpine. Not needed in s390x
+FROM ${GO_BORING} AS builder-amd64
+FROM builder AS builder-s390x
+FROM builder-${ARCH} AS calico-node-builder
+ARG ARCH
+RUN if [ "${ARCH}" = "amd64" ]; then apt -y update && apt -y upgrade && apt install -y file libbpf-dev gcc build-essential libelf-dev; fi
+COPY --from=builder /usr/local/go/bin/go-assert-boring.sh /usr/local/go/bin/go-assert-static.sh /usr/local/go/bin/go-build-static.sh /usr/local/go/bin/
 
 ### BEGIN K3S XTABLES ###
 FROM builder AS k3s_xtables
@@ -71,22 +80,26 @@ RUN install -s bin/* /opt/cni/bin/
 
 
 ### BEGIN CALICO NODE ###
-FROM builder AS calico_node
+FROM calico-node-builder AS calico_node
 ARG ARCH
 ARG TAG
 RUN git clone --depth=1 https://github.com/projectcalico/node.git $GOPATH/src/github.com/projectcalico/node
 WORKDIR $GOPATH/src/github.com/projectcalico/node
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
+RUN mkdir -p bin/third-party && go mod download && cp -r `go list -mod=mod -m -f "{{.Dir}}" github.com/projectcalico/felix`/bpf-gpl/include/libbpf bin/third-party && chmod -R +w bin/third-party
+RUN if [ "${ARCH}" = "amd64" ]; then make -j 16 -C bin/third-party/libbpf/src BUILD_STATIC_ONLY=1; fi
 RUN GO_LDFLAGS="-linkmode=external \
     -X github.com/projectcalico/node/pkg/startup.VERSION=${TAG} \
     -X github.com/projectcalico/node/buildinfo.GitRevision=$(git rev-parse HEAD) \
     -X github.com/projectcalico/node/buildinfo.GitVersion=$(git describe --tags --always) \
-    -X github.com/projectcalico/node/buildinfo.BuildDate=$(date -u +%FT%T%z) \
-    " go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/calico-node ./cmd/calico-node
-RUN go-assert-static.sh bin/*
-RUN if [ "${ARCH}" = "amd64" ]; then go-assert-boring.sh bin/*; fi
-RUN install -s bin/* /usr/local/bin
+    -X github.com/projectcalico/node/buildinfo.BuildDate=$(date -u +%FT%T%z)" \
+    CGO_LDFLAGS="-L/go/src/github.com/projectcalico/node/bin/third-party/libbpf/src -lbpf -lelf -lz" \
+    CGO_CFLAGS="-I/go/src/github.com/projectcalico/node/bin/third-party/libbpf/src" \
+    CGO_ENABLED=1 go build -ldflags "-linkmode=external -extldflags \"-static\"" -gcflags=-trimpath=${GOPATH}/src -o bin/calico-node ./cmd/calico-node
+RUN go-assert-static.sh bin/calico-node
+RUN go-assert-boring.sh bin/calico-node
+RUN install -s bin/calico-node /usr/local/bin
 ### END CALICO NODE #####
 
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
-TAG ?= v3.20.3$(BUILD_META)
+TAG ?= v3.21.2$(BUILD_META)
 
 K3S_ROOT_VERSION ?= v0.10.1
 


### PR DESCRIPTION
This upgrade has three significant changes:

1 - Starting from v3.21, calico-node build requires bpf for amd64 architectures. Unfortunately, it is not possible to build bpf on alpine because libbpf-dev and libelf-dev packages do not exist there. That's why, we can't use our hardened-build-base image for calico-node build. Instead, we use goboring/golang image to build it, which is based on debian and includes those packages. As we are building statically, it does not matter where we build it. Note that the final binary is correctly verified with both `go-assert-static.sh` and `go-assert-boring.sh`

2 - Some extra lines are required in the calico-node build process. Basically, copying the bpf sources from `projectcalico/felix` and building the bpf code with `make -j 16 -C bin/third-party/libbpf/src BUILD_STATIC_ONLY=1`. Apart from that, we must pass the location of the bpf code and the elf, libbpf and zlib libraries to cgo via `CGO_LDFLAGS` and `CGO_CFLAGS`

3 - The cgo code that calls the bpf code uses some functions that require glibc (or musl) and thus, when building, we get a few warnings. For example:
```
/usr/bin/ld: /tmp/go-link-663099537/000004.o: in function `_cgo_26061493d47f_C2func_getaddrinfo':
cgo_unix.cgo2.c:(.text+0x81): warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```
As we will never use bpf in canal, everything still works fine. However, we can't build with `go-build-static.sh` because it makes the build fail in case of warnings. I just copied everything as it is in the script and removed the extdflag `-Wl,--fatal-warnings` to avoid that behavior

Finally, the following lines are needed to not break s390x builds:
```
FROM ${GO_BORING} AS builder-amd64
FROM builder AS builder-s390x
FROM builder-${ARCH} AS calico-node-builder
```
The reason is that goboring image is not supported on s390x. As bpf is not needed in that arch, we are just forcing to continue using builder (based on Alpine) when ARCH=s390x

Signed-off-by: Manuel Buil <mbuil@suse.com>