### PR TITLE
DO NOT MERGE - Update to bci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG ARCH="amd64"
 ARG TAG="v3.22.0"
-ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
+ARG BCI_IMAGE=registry.suse.com/bci/bci-base:latest
 ARG GO_IMAGE=rancher/hardened-build-base:v1.17.6b7
 ARG CNI_IMAGE=rancher/hardened-cni-plugins:v1.0.1-build20220223
 ARG GO_BORING=goboring/golang:1.16.7b7
 ARG GOBORING_GOLANG_VERSION=1.17.6
 ARG GOBORING_BUILD=7
 
-FROM ${UBI_IMAGE} as ubi
+FROM ${BCI_IMAGE} as bci
 FROM ${CNI_IMAGE} as cni
 FROM ${GO_IMAGE} as builder
 # setup required packages
@@ -152,7 +152,7 @@ RUN install -D -s bin/check-status /usr/local/bin/
 ### END CALICO KUBE-CONTROLLERS #####
 
 ### BEGIN RUNIT ###
-# We need to build runit because there aren't any rpms for it in CentOS or ubi repositories.
+# We need to build runit because there aren't any rpms for it in CentOS or bci repositories.
 FROM centos:7 AS runit-amd64
 FROM clefos:7 AS runit-s390x
 FROM runit-${ARCH} AS runit
@@ -161,7 +161,7 @@ ARG RUNIT_VER=2.1.2
 RUN yum install -y rpm-build yum-utils make && \
     yum install -y wget glibc-static gcc    && \
     yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
-# runit is not available in ubi or CentOS repos so build it.
+# runit is not available in bci or CentOS repos so build it.
 ADD http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz /tmp/runit.tar.gz
 WORKDIR /opt/local
 RUN tar xzf /tmp/runit.tar.gz --strip-components=2 -C .
@@ -201,14 +201,14 @@ COPY --from=runit /opt/local/command/                /usr/sbin/
 
 FROM calico_rootfs_overlay_${ARCH} as calico_rootfs_overlay
 
-FROM ubi
-RUN microdnf update -y                         && \
-    microdnf install hostname                     \
-    libpcap libmnl libnetfilter_conntrack         \
-    libnetfilter_cthelper libnetfilter_cttimeout  \
-    libnetfilter_queue ipset kmod iputils iproute \
-    procps net-tools conntrack-tools which     && \
-    rm -rf /var/cache/yum
+FROM bci
+RUN zypper update -y                             && \
+    zypper install -y hostname                      \
+    libpcap1 libmnl0 libnetfilter_conntrack3        \
+    libnetfilter_cthelper0 libnetfilter_cttimeout1  \
+    libnetfilter_queue1 ipset kmod iputils iproute2 \
+    net-tools conntrack-tools which     && \
+    zypper clean --all
 COPY --from=calico_rootfs_overlay / /
 ENV PATH=$PATH:/opt/cni/bin
 RUN set -x \


### PR DESCRIPTION
BCI migration PR. As shown below only libcap is using an older version, the other libraries are fine.

| package | bci version | ubi version |
| ------- |:-----------:|:-----------:|
| libcap | 1.9.1-1.33 | 2.22-11 |
| libmnl | 1.0.4-1.25 | 1.0.3-7 |
| libnetfilter_conntrack | 1.0.7-1.38 | 1.0.6-1 |
| libnetfilter_cthelper | 1.0.0-1.21 | 1.0.0-11 |
| libnetfilter_cttimeout | 1.0.0-1.22 | 1.0.0-7 |
| libnetfilter_queue | 1.0.3-1.16 | 1.0.2-2 |

