### PR TITLE
Update BCI image and Calico version to 3.25.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
-ARG TAG="v3.25.0"
-ARG BCI_IMAGE=registry.suse.com/bci/bci-base:15.3.17.20.12
+ARG TAG="v3.25.1"
+ARG BCI_IMAGE=registry.suse.com/bci/bci-base:15.4.27.14.55
 ARG GO_IMAGE=rancher/hardened-build-base:v1.19.1b1
 ARG CNI_IMAGE=rancher/hardened-cni-plugins:v1.0.1-build20221011
 ARG GO_BORING=goboring/golang:1.16.7b7

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
-TAG ?= v3.25.0$(BUILD_META)
+TAG ?= v3.25.1$(BUILD_META)
 
 K3S_ROOT_VERSION ?= v0.11.0
 

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Build
 
 ```sh
-TAG=v3.25.0 make
+TAG=v3.25.1 make
 ```


### PR DESCRIPTION
Update BCI image to the latest version with updated ipset to fix https://github.com/rancher/rke2/issues/4145
Update calico to version v3.25.1