### PR TITLE
Add dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "rancher/k3s"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "rancher/k3s"


### PR DESCRIPTION
This adds rancher/k3s to the PRs that dependabot generates.
This contributes to https://github.com/rancher/rke2/issues/4143.
I tested this by running [the dependabot cli](https://github.com/dependabot/cli) locally:
<details>
  <summary>Test Scenario</summary>

```
input:
  job:
    package-manager: docker
    allowed-updates:
      - update-type: all
    ignore-conditions:
      - dependency-name: centos
        source: dependabot_test
        version-requirement: '>8'
    source:
      provider: github
      repo: rancher/image-build-calico
      directory: /
      commit: 8424dc4baca42521f856ee67c70173731cf43d85
    credentials-metadata:
      - host: github.com
        type: git_source
  credentials:
    - host: github.com
      password: $LOCAL_GITHUB_ACCESS_TOKEN
      type: git_source
      username: x-access-token
output:
  - type: update_dependency_list
    expect:
      data:
        dependencies:
          - name: calico/bird
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: v0.3.3-184-g202a2186-
            version: v0.3.3-184-g202a2186-
          - name: centos
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: "7"
            version: "7"
          - name: clefos
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: "7"
            version: "7"
        dependency_files:
          - /Dockerfile
  - type: create_pull_request
    expect:
      data:
        base-commit-sha: 8424dc4baca42521f856ee67c70173731cf43d85
        dependencies:
          - name: centos
            previous-requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: "7"
            previous-version: "7"
            requirements:
              - file: Dockerfile
                groups: []
                requirement: null
                source:
                  tag: "8"
            version: "8"
        updated-dependency-files:
          - content_encoding: utf-8
            deleted: false
            directory: /
            name: Dockerfile
            operation: update
            support_file: false
            type: file
        pr-title: Bump centos from 7 to 8
        pr-body: |
          Bumps centos from 7 to 8.
        commit-message: |-
          Bump centos from 7 to 8
          Bumps centos from 7 to 8.
  - type: mark_as_processed
    expect:
      data:
        base-commit-sha: 8424dc4baca42521f856ee67c70173731cf43d85
```

</details>