### PR TITLE
Fix drone tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -47,6 +47,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/tags/*
+      - refs/pull/**
 
 volumes:
 - name: docker
@@ -70,6 +76,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/master
+      - refs/tags/*
+      - refs/pull/**
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.7b3


### PR DESCRIPTION
Drone yaml file is currently wrong for amd64, it clones the project and then runs the scan without running build, thus miserably failing: https://drone-publish.rancher.io/rancher/image-build-calico/139/3