### PR TITLE
Versions bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG ARCH="amd64"
-ARG TAG="v3.26.3"
+ARG TAG="v3.27.0"
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
 ARG GO_IMAGE=rancher/hardened-build-base:v1.20.7b3
-ARG CNI_IMAGE=rancher/hardened-cni-plugins:v1.2.0-build20230523
+ARG CNI_IMAGE=rancher/hardened-cni-plugins:v1.4.0-build20240122
 ARG GOEXPERIMENT=boringcrypto
 
 FROM ${BCI_IMAGE} as bci
@@ -31,7 +31,7 @@ RUN git checkout tags/${TAG} -b ${TAG}
 ### BEGIN K3S XTABLES ###
 FROM builder AS k3s_xtables
 ARG ARCH
-ARG K3S_ROOT_VERSION=v0.11.0
+ARG K3S_ROOT_VERSION=v0.13.0
 ADD https://github.com/rancher/k3s-root/releases/download/${K3S_ROOT_VERSION}/k3s-root-xtables-${ARCH}.tar /opt/xtables/k3s-root-xtables.tar
 RUN tar xvf /opt/xtables/k3s-root-xtables.tar -C /opt/xtables
 ### END K3S XTABLES #####

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,9 @@ endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
-TAG ?= v3.26.3$(BUILD_META)
+TAG ?= v3.27.0$(BUILD_META)
 
-K3S_ROOT_VERSION ?= v0.11.0
-
-CNI_PLUGINS_VERSION ?= v1.2.0
+K3S_ROOT_VERSION ?= v0.13.0
 
 ifneq ($(DRONE_TAG),)
 	TAG := $(DRONE_TAG)
@@ -31,7 +29,6 @@ image-build:
 	DOCKER_BUILDKIT=1 docker build --no-cache \
 		--pull \
 		--build-arg ARCH=$(ARCH) \
-		--build-arg CNI_PLUGINS_VERSION=$(CNI_PLUGINS_VERSION) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
 		--build-arg K3S_ROOT_VERSION=$(K3S_ROOT_VERSION) \
 		--tag $(ORG)/hardened-calico:$(TAG) \


### PR DESCRIPTION
Bumps versions of:
* calico
* cni-plugins
* k3s-root

Removes `CNI_PLUGINS_VERSION` variable from Makefile which is not used at all