### PR TITLE
Use updatecli to update versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 ARG ARCH="amd64"
-ARG TAG="v3.27.0"
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
 ARG GO_IMAGE=rancher/hardened-build-base:v1.21.6b2
-ARG CNI_IMAGE=rancher/hardened-cni-plugins:v1.4.0-build20240122
+ARG CNI_IMAGE_VERSION=v1.4.0-build20240122
+ARG CNI_IMAGE=rancher/hardened-cni-plugins:${CNI_IMAGE_VERSION}
 ARG GOEXPERIMENT=boringcrypto
 
 FROM ${BCI_IMAGE} as bci
 FROM ${CNI_IMAGE} as cni
 FROM ${GO_IMAGE} as builder
 # setup required packages
-ARG TAG
+ARG TAG=v3.27.0
 RUN set -x && \
     apk --no-cache add \
     bash \
@@ -43,7 +43,7 @@ FROM calico/bird:v0.3.3-184-g202a2186-${ARCH} AS calico_bird
 ### BEGIN CALICOCTL ###
 FROM builder AS calico_ctl
 ARG ARCH
-ARG TAG
+ARG TAG=v3.27.0
 ARG GOEXPERIMENT
 WORKDIR $GOPATH/src/github.com/projectcalico/calico/calicoctl
 RUN GO_LDFLAGS="-linkmode=external \
@@ -60,7 +60,7 @@ RUN calicoctl --version
 ### BEGIN CALICO CNI ###
 FROM builder AS calico_cni
 ARG ARCH
-ARG TAG
+ARG TAG=v3.27.0
 ARG GOEXPERIMENT
 WORKDIR $GOPATH/src/github.com/projectcalico/calico/cni-plugin
 COPY dualStack-changes.patch .
@@ -81,7 +81,7 @@ RUN install -s bin/* /opt/cni/bin/
 ### Can't use go-build-static.sh due to -Wl and --fatal-warnings flags ###
 FROM builder AS calico_node
 ARG ARCH
-ARG TAG
+ARG TAG=v3.27.0
 ARG GOEXPERIMENT
 WORKDIR $GOPATH/src/github.com/projectcalico/calico/node
 RUN go mod download
@@ -123,7 +123,7 @@ RUN install -D -s bin/flexvoldriver /usr/local/bin/flexvol/flexvoldriver
 
 ### BEGIN CALICO KUBE-CONTROLLERS ###
 FROM builder AS calico_kubecontrollers
-ARG TAG
+ARG TAG=v3.27.0
 ARG GOEXPERIMENT
 WORKDIR $GOPATH/src/github.com/projectcalico/calico/kube-controllers
 RUN GO_LDFLAGS="-linkmode=external \

--- a/updatecli/updatecli.d/updatecalico.yaml
+++ b/updatecli/updatecli.d/updatecalico.yaml
@@ -1,0 +1,74 @@
+---
+name: "Update calico version" 
+
+sources:
+ calico:
+   name: Get calico version
+   kind: githubrelease
+   spec:
+     owner: projectcalico
+     repository: calico
+     token: '{{ requiredEnv .github.token }}'
+     typefilter:
+       release: true
+       draft: false
+       prerelease: false
+     versionfilter:
+       kind: latest
+
+targets:
+  dockerfile:
+    name: "Bump to latest calico version in Dockerfile"
+    kind: dockerfile
+    scmid: default
+    sourceid: calico
+    spec:
+      file: "Dockerfile"
+      instruction:
+        keyword: "ARG"
+        matcher: "TAG"
+
+  makefile:
+    name: "Bump to latest calico version in Makefile"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: Makefile
+      matchpattern: '(?m)^TAG \?\= (.*)'
+      replacepattern: 'TAG ?= {{ source "calico" }}$$(BUILD_META)'
+
+  readme:
+    name: "Bump to latest calico version in README"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: README.md
+      matchpattern: '(?m)^TAG=(.*)'
+      replacepattern: 'TAG={{ source "calico" }} make'
+
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.username }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+    default:
+        title: 'Bump calico version to {{ source "calico" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created 
+        scmid: default

--- a/updatecli/updatecli.d/updatek3sroot.yaml
+++ b/updatecli/updatecli.d/updatek3sroot.yaml
@@ -1,0 +1,63 @@
+---
+name: "Update k3sroot version" 
+
+sources:
+ k3sroot:
+   name: Get k3s-root version
+   kind: githubrelease
+   spec:
+     owner: k3s-io
+     repository: k3s-root
+     token: '{{ requiredEnv .github.token }}'
+     typefilter:
+       release: true
+       draft: false
+       prerelease: false
+     versionfilter:
+       kind: latest
+
+targets:
+  dockerfile:
+    name: "Bump to latest k3s-root version in Dockerfile"
+    kind: dockerfile
+    scmid: default
+    sourceid: k3sroot
+    spec:
+      file: "Dockerfile"
+      instruction:
+        keyword: "ARG"
+        matcher: "K3S_ROOT_VERSION"
+
+  makefile:
+    name: "Bump to latest k3s-root version in Makefile"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: Makefile
+      matchpattern: '(?m)^K3S_ROOT_VERSION \?\= (.*)'
+      replacepattern: 'K3S_ROOT_VERSION ?= {{ source "k3sroot" }}'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+    default:
+        title: 'Bump K3s-root version to {{ source "k3sroot" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created
+        scmid: default
+

--- a/updatecli/updatecli.d/updateplugins.yaml
+++ b/updatecli/updatecli.d/updateplugins.yaml
@@ -1,0 +1,53 @@
+---
+name: "Update cniplugins version" 
+
+sources:
+ cniplugins:
+   name: Get cniplugins version
+   kind: githubrelease
+   spec:
+     owner: rancher
+     repository: image-build-cni-plugins
+     token: '{{ requiredEnv .github.token }}'
+     typefilter:
+       release: true
+       draft: false
+       prerelease: false
+     versionfilter:
+       kind: latest
+
+targets:
+  dockerfile:
+    name: "Bump to latest cniplugins version in Dockerfile"
+    kind: dockerfile
+    scmid: default
+    sourceid: cniplugins
+    spec:
+      file: "Dockerfile"
+      instruction:
+        keyword: "ARG"
+        matcher: "CNI_IMAGE_VERSION"
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+    default:
+        title: 'Bump cniplugins version to {{ source "cniplugins" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created
+        scmid: default
+

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -3,3 +3,6 @@ github:
   email: "41898282+github-actions[bot]@users.noreply.github.com"
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
+  repository: "image-build-calico"
+  branch: "master"
+  owner: "rancher"


### PR DESCRIPTION
This PR adapts Dockerfile a bit so that it is easy to change the versions with updateCLI.

It adds a policy for:
* Calico version
* cniplugins version
* k3sroot version