### PR TITLE
Use updatecli to update the base image in drone

### DIFF
--- a/updatecli/updatecli.d/updatebuildbase.yaml
+++ b/updatecli/updatecli.d/updatebuildbase.yaml
@@ -2,9 +2,20 @@
 name: "Update build base version" 
 
 sources:
- buildbase:
+  gomod:
+    name: Get latest Golang version based on go.mod
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/projectcalico/calico/master/go.mod
+      matchpattern: 'go ([0-9]+\.[0-9]+)'
+    transformers:
+      - trimprefix: "go "
+
+  buildbase:
    name: Get build base version
    kind: githubrelease
+   dependson:
+     - "gomod"
    spec:
      owner: rancher
      repository: image-build-base
@@ -14,7 +25,8 @@ sources:
        draft: false
        prerelease: false
      versionfilter:
-       kind: latest
+       kind: regex
+       pattern: '{{ source "gomod"}}\.\S+'
 
 targets:
   dockerfile:
@@ -29,6 +41,16 @@ targets:
         matcher: "GO_IMAGE"
     transformers:
       - addprefix: "rancher/hardened-build-base:"
+
+  drone:
+    name: "Bump to latest build base version in Dockerfile"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: .drone.yml
+      matchpattern: '(?m)^  image: rancher/hardened-build-base:(.*)'
+      replacepattern: '  image: rancher/hardened-build-base:{{ source "buildbase" }}'
 
 scms:
   default:


### PR DESCRIPTION
This PR also searches for the go.mod version in the upstream project

Works: https://github.com/rancher/image-build-calico/pull/69