### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifneq ($(DRONE_TAG),)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))
-	$(error TAG needs to end with build metadata: $(BUILD_META))
+$(error TAG needs to end with build metadata: $(BUILD_META))
 endif
 
 .PHONY: image-build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,1 @@
 # rancher/hardened-calico
-
-## Build
-
-```sh
-TAG=v3.27.2 make
-```

--- a/updatecli/updatecli.d/updatecalico.yaml
+++ b/updatecli/updatecli.d/updatecalico.yaml
@@ -38,17 +38,6 @@ targets:
       matchpattern: '(?m)^TAG \?\= (.*)'
       replacepattern: 'TAG ?= {{ source "calico" }}$$(BUILD_META)'
 
-  readme:
-    name: "Bump to latest calico version in README"
-    kind: file
-    scmid: default
-    disablesourceinput: true
-    spec:
-      file: README.md
-      matchpattern: '(?m)^TAG=(.*)'
-      replacepattern: 'TAG={{ source "calico" }} make'
-
-
 scms:
   default:
     kind: github


### PR DESCRIPTION
The tab in the Makefile is wrong because in that case it believes it is a recipe, so we get the error:
```
*** recipe commences before first target.  Stop.
```
As the Makefile is quite simple, and has been wrong for a long time, I think it is fine if we just remove the instruction. Then we tell updatecli to not update it anymore