### PR TITLE
Use correct step names for digest export

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -19,7 +19,7 @@ jobs:
       uses: docker/setup-qemu-action@v3
 
     - name: Docker meta
-      id: meta
+      id: meta-amd64
       uses: docker/metadata-action@v5
       with:
         images: ${{ env.REGISTRY_IMAGE }}
@@ -41,18 +41,19 @@ jobs:
         password: ${{ env.DOCKER_PASSWORD }}
 
     - name: Build container image
+      id: build-amd64
       uses: docker/build-push-action@v5
       with:
         context: .
         file: Dockerfile
         platforms: linux/amd64
-        labels: ${{ steps.meta.outputs.labels }}
+        labels: ${{ steps.meta-amd64.outputs.labels }}
         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
     - name: Export digest
       run: |
         mkdir -p /tmp/digests
-        digest="${{ steps.build-amd64-digest.outputs.digest }}"
+        digest="${{ steps.build-amd64.outputs.digest }}"
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
@@ -76,7 +77,7 @@ jobs:
       uses: docker/setup-qemu-action@v3
 
     - name: Docker meta
-      id: meta
+      id: meta-arm64
       uses: docker/metadata-action@v5
       with:
         images: ${{ env.REGISTRY_IMAGE }}
@@ -98,18 +99,19 @@ jobs:
         password: ${{ env.DOCKER_PASSWORD }}
 
     - name: Build container image
+      id: build-arm64
       uses: docker/build-push-action@v5
       with:
         context: .
         file: Dockerfile
         platforms: linux/arm64
-        labels: ${{ steps.meta.outputs.labels }}
+        labels: ${{ steps.meta-arm64.outputs.labels }}
         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
     - name: Export digest
       run: |
         mkdir -p /tmp/digests
-        digest="${{ steps.build-arm64-digest.outputs.digest }}"
+        digest="${{ steps.build-arm64.outputs.digest }}"
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest


### PR DESCRIPTION
This PR adds ids to job steps and uses these to properly reference the outputs of the steps where needed (e.g. when exporting the digest of the image).