### PR TITLE
set 'latest: true' in updatecli typefilter

### DIFF
--- a/updatecli/updatecli.d/updatecalico.yaml
+++ b/updatecli/updatecli.d/updatecalico.yaml
@@ -13,6 +13,7 @@ sources:
        release: true
        draft: false
        prerelease: false
+       latest: true
      versionfilter:
        kind: latest
 


### PR DESCRIPTION
This should ensures that there are no PRs "updating" to a lower minor release