### PR TITLE
updatecli: use `semver` versionfilter

### DIFF
--- a/updatecli/updatecli.d/updatecalico.yaml
+++ b/updatecli/updatecli.d/updatecalico.yaml
@@ -13,9 +13,8 @@ sources:
        release: true
        draft: false
        prerelease: false
-       latest: true
      versionfilter:
-       kind: latest
+       kind: semver
 
 targets:
   dockerfile:

--- a/updatecli/updatecli.d/updatek3sroot.yaml
+++ b/updatecli/updatecli.d/updatek3sroot.yaml
@@ -14,7 +14,7 @@ sources:
        draft: false
        prerelease: false
      versionfilter:
-       kind: latest
+       kind: semver
 
 targets:
   dockerfile:

--- a/updatecli/updatecli.d/updateplugins.yaml
+++ b/updatecli/updatecli.d/updateplugins.yaml
@@ -14,7 +14,7 @@ sources:
        draft: false
        prerelease: false
      versionfilter:
-       kind: latest
+       kind: semver
 
 targets:
   dockerfile:


### PR DESCRIPTION
Version bump PRs should use the semver instead of the latest tag

Issue: https://github.com/rancher/rke2/issues/6402