### PR TITLE
Fixup push of release builds to the prime registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
     types: [published]
 
 env:
-  REGISTRY_IMAGE: rancher/hardened-calico
   GITHUB_ACTION_TAG: ${{ github.ref_name }}  
 
 jobs:
@@ -23,6 +22,7 @@ jobs:
       run: |
         echo "$(make -s log | grep TAG)" >> "$GITHUB_ENV"
         echo "$(make -s log | grep ARCH)" >> "$GITHUB_ENV"
+        echo "$(make -s log | grep REGISTRY_IMAGE)" >> "$GITHUB_ENV"
 
     - name: Docker meta
       id: meta-amd64

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ TAG := v3.29.1$(BUILD_META)
 endif
 
 REPO ?= rancher
-REGISTRY_IMAGE ?= $(REPO)/hardened-calico
-IMAGE ?= $(REGISTRY_IMAGE):$(TAG)
+REGISTRY_IMAGE = $(REPO)/hardened-calico
+IMAGE = $(REGISTRY_IMAGE):$(TAG)
 
 LABEL_ARGS = $(foreach label,$(META_LABELS),--label $(label))
 
@@ -91,6 +91,7 @@ log:
 	@echo "ARCH=$(ARCH)"
 	@echo "TAG=$(TAG:$(BUILD_META)=)"
 	@echo "REPO=$(REPO)"
+	@echo "REGISTRY_IMAGE=$(REGISTRY_IMAGE)"
 	@echo "PKG=$(PKG)"
 	@echo "SRC=$(SRC)"
 	@echo "BUILD_META=$(BUILD_META)"


### PR DESCRIPTION
The prime repository prefix was overwritten, causing the built image to push twice to `docker.io`