### PR TITLE
Set `REGISTRY_IMAGE` env during the merge job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
       run: |
         echo "$(make -s log | grep TAG)" >> "$GITHUB_ENV"
         echo "$(make -s log | grep ARCH)" >> "$GITHUB_ENV"
+        echo "$(make -s log | grep REGISTRY_IMAGE)" >> "$GITHUB_ENV"
 
     - name: Docker meta
       id: meta-arm64
@@ -134,6 +135,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Set the ENV values
+        id: get-Envs
+        run: |
+          echo "$(make -s log | grep REGISTRY_IMAGE)" >> "$GITHUB_ENV"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
`docker/metadata-action` step and `manifest-push` need a valid `REGISTRY_IMAGE` var set during the merge job

Fixup for: 4cd229ed92087b2126828e885b7dd02dcedd972b
Signed-off-by: Michael Fritch <mfritch@suse.com>