### PR TITLE
Use unique artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Upload metadata files
       uses: actions/upload-artifact@v4
       with:
-        name: metadata-files
+        name: metadata-amd64
         path: ${{ env.BUILDDIR}}
         if-no-files-found: error
         retention-days: 1
@@ -122,7 +122,7 @@ jobs:
     - name: Upload metadata files
       uses: actions/upload-artifact@v4
       with:
-        name: metadata-files
+        name: metadata-arm64
         path: ${{ env.BUILDDIR}}
         if-no-files-found: error
         retention-days: 1


### PR DESCRIPTION
`actions/upload-artifact` requires a unqiue name for each artifact to upload (e.g. `amd64`, `arm64` etc.)

Fixes:
https://github.com/rancher/image-build-calico/actions/runs/12272456160

```
Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```