### PR TITLE
[LTS] Fix inspect image CI step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,4 +200,4 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.PRIME_REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
The "Inspect Image" step doesn't specify from which registry the image should be pulled from, so it defaults to `docker.io`, this PR prepends the Prime Registry to the image name:version.