### PR TITLE
Revert to calico `v3.29.1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM ${BCI_IMAGE} AS bci
 FROM ${CNI_IMAGE} AS cni
 FROM ${GO_IMAGE} AS builder
 # setup required packages
-ARG TAG=v3.29.2
+ARG TAG=v3.29.1
 RUN set -x && \
     apk --no-cache add \
     bash \
@@ -43,7 +43,7 @@ FROM calico/bird:v0.3.3-184-g202a2186-${ARCH} AS calico_bird
 ### BEGIN CALICOCTL ###
 FROM builder AS calico_ctl
 ARG ARCH
-ARG TAG=v3.29.2
+ARG TAG=v3.29.1
 ARG GOEXPERIMENT
 WORKDIR $GOPATH/src/github.com/projectcalico/calico/calicoctl
 RUN GIT_COMMIT=$(git rev-parse --short HEAD) \
@@ -61,7 +61,7 @@ RUN calicoctl --version
 ### BEGIN CALICO CNI ###
 FROM builder AS calico_cni
 ARG ARCH
-ARG TAG=v3.29.2
+ARG TAG=v3.29.1
 ARG GOEXPERIMENT
 WORKDIR $GOPATH/src/github.com/projectcalico/calico/cni-plugin
 COPY dualStack-changes.patch .
@@ -82,7 +82,7 @@ RUN install -s bin/* /opt/cni/bin/
 ### Can't use go-build-static.sh due to -Wl and --fatal-warnings flags ###
 FROM builder AS calico_node
 ARG ARCH
-ARG TAG=v3.29.2
+ARG TAG=v3.29.1
 ARG GOEXPERIMENT
 WORKDIR $GOPATH/src/github.com/projectcalico/calico/node
 RUN go mod download
@@ -124,7 +124,7 @@ RUN install -D -s bin/flexvoldriver /usr/local/bin/flexvol/flexvoldriver
 
 ### BEGIN CALICO KUBE-CONTROLLERS ###
 FROM builder AS calico_kubecontrollers
-ARG TAG=v3.29.2
+ARG TAG=v3.29.1
 ARG GOEXPERIMENT
 WORKDIR $GOPATH/src/github.com/projectcalico/calico/kube-controllers
 RUN GO_LDFLAGS="-linkmode=external \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ MACHINE := rancher
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v3.29.2$(BUILD_META)
+TAG := v3.29.1$(BUILD_META)
 endif
 
 REPO ?= rancher


### PR DESCRIPTION
This reverts commits:
- 1b8f5dfe27a24bfe31e62de78c496afab2ef631b
- 9f8627d61af3a88cd09f244a80bcc57ab19f11e0