### PR TITLE
Use github.event.release.tag_name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
     types: [published]
 
 env:
-  GITHUB_ACTION_TAG: ${{ github.ref_name }}  
+  GITHUB_ACTION_TAG: ${{ github.event.release.tag_name }}  
 
 jobs:
   build-amd64-digest:


### PR DESCRIPTION
According to GH doc, github.ref_name can be incosnsistent and can be empty