### PR TITLE
updatecli: Update BCI base image to the latest digest 

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -55,3 +55,5 @@ jobs:
         env:
           UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_REPO: ${{ github.event.repository.name }}
+          UPDATECLI_GITHUB_BRANCH: ${{ github.ref_name }}

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install Updatecli
         uses: updatecli/updatecli-action@5dfc616e57b07d2302c3f37e5b72a4ead82dbbf8 # v3.4.0
 
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+
       - name: Delete leftover UpdateCLI branches
         run: |
           gh pr list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=${TARGETARCH}
-ARG BCI_IMAGE=registry.suse.com/bci/bci-base
+ARG BCI_IMAGE=registry.suse.com/bci/bci-base:15.7-5.20.53@sha256:daebf54bd4ab8b05e1e64597d8ea63b242605e936cff16460d0cfdb9716a896a
 ARG GO_IMAGE=rancher/hardened-build-base:v1.25.12b1
 ARG CNI_IMAGE_VERSION=v1.9.1-build20260717
 ARG CNI_IMAGE=rancher/hardened-cni-plugins:${CNI_IMAGE_VERSION}

--- a/updatecli/scripts/should-update-bci-digest.sh
+++ b/updatecli/scripts/should-update-bci-digest.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Returns exit code 0 only when:
+# 1) current image has at least one HIGH/CRITICAL OS CVE
+# 2) candidate image has fewer HIGH/CRITICAL OS CVEs than current image
+
+CURRENT_IMAGE_REF="${1:-}"
+CANDIDATE_IMAGE_REF="${2:-}"
+DEFAULT_TAG="${3:-}"
+DEFAULT_IMAGE_NAME=""
+
+if [[ -z "${CURRENT_IMAGE_REF}" || -z "${CANDIDATE_IMAGE_REF}" ]]; then
+  echo "usage: $0 <current-image-ref> <candidate-image-ref> [default-tag]" >&2
+  exit 2
+fi
+
+infer_image_name_from_ref() {
+  local ref ref_without_digest tail
+  ref="$1"
+
+  # Drop digest part first (if any), then strip tag from the last path element.
+  ref_without_digest="${ref%@*}"
+  tail="${ref_without_digest##*/}"
+  if [[ "${tail}" == *:* ]]; then
+    echo "${ref_without_digest%:*}"
+    return 0
+  fi
+
+  echo "${ref_without_digest}"
+}
+
+normalize_ref() {
+  local ref default_tag default_image
+  ref="$1"
+  default_tag="$2"
+  default_image="$3"
+
+  # If the value is only a digest, prepend image name.
+  if [[ "${ref}" =~ ^sha256: ]]; then
+    if [[ -z "${default_image}" ]]; then
+      echo "cannot normalize digest-only reference without image name" >&2
+      exit 2
+    fi
+    echo "${default_image}@${ref}"
+    return 0
+  fi
+
+  # Already a digest reference.
+  if [[ "${ref}" == *@sha256:* ]]; then
+    echo "${ref}"
+    return 0
+  fi
+
+  # Tag reference: detect ':' after the last '/'.
+  local tail
+  tail="${ref##*/}"
+  if [[ "${tail}" == *:* ]]; then
+    echo "${ref}"
+    return 0
+  fi
+
+  # Bare image name fallback.
+  if [[ -n "${default_tag}" ]]; then
+    echo "${ref}:${default_tag}"
+    return 0
+  fi
+
+  echo "${ref}"
+}
+
+count_high_critical_os_vulns() {
+  local image_ref output_file
+  image_ref="$1"
+  output_file="$2"
+
+  trivy image \
+    --quiet \
+    --format json \
+    --output "${output_file}" \
+    --severity HIGH,CRITICAL \
+    --vuln-type os \
+    --ignore-unfixed=false \
+    --exit-code 0 \
+    "${image_ref}" >/dev/null
+
+  jq '[.Results[]? | select(.Class == "os-pkgs") | .Vulnerabilities[]? | select(.Severity == "HIGH" or .Severity == "CRITICAL")] | length' "${output_file}"
+}
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+current_json="${workdir}/current.json"
+candidate_json="${workdir}/candidate.json"
+
+DEFAULT_IMAGE_NAME="$(infer_image_name_from_ref "${CANDIDATE_IMAGE_REF}")"
+CURRENT_IMAGE_REF="$(normalize_ref "${CURRENT_IMAGE_REF}" "${DEFAULT_TAG}" "${DEFAULT_IMAGE_NAME}")"
+CANDIDATE_IMAGE_REF="$(normalize_ref "${CANDIDATE_IMAGE_REF}" "${DEFAULT_TAG}" "${DEFAULT_IMAGE_NAME}")"
+
+current_count="$(count_high_critical_os_vulns "${CURRENT_IMAGE_REF}" "${current_json}")"
+candidate_count="$(count_high_critical_os_vulns "${CANDIDATE_IMAGE_REF}" "${candidate_json}")"
+
+echo "Current image: ${CURRENT_IMAGE_REF}"
+echo "Candidate image: ${CANDIDATE_IMAGE_REF}"
+echo "Current HIGH/CRITICAL OS CVEs: ${current_count}"
+echo "Candidate HIGH/CRITICAL OS CVEs: ${candidate_count}"
+
+if (( current_count > 0 && candidate_count < current_count )); then
+  echo "Decision: update allowed (candidate is safer)."
+  exit 0
+fi
+
+echo "Decision: update blocked (no security improvement)."
+exit 1

--- a/updatecli/updatecli.d/update-bci-base.yaml
+++ b/updatecli/updatecli.d/update-bci-base.yaml
@@ -1,13 +1,13 @@
 ---
-name: 'Update BCI base version'
+name: 'Update BCI base image digest'
 
 sources:
   digest:
     name: Get latest BCI base image digest
     kind: dockerdigest
     spec:
-      image: 'registry.suse.com/bci/bci-base'
-      tag: 'latest'
+      image: '{{ .image.bci.name }}'
+      tag: '{{ .image.bci.tag }}'
 
 conditions:
   image:
@@ -15,7 +15,7 @@ conditions:
     kind: dockerimage
     sourceid: digest
     spec:
-      image: registry.suse.com/bci/bci-base
+      image: '{{ .image.bci.name }}'
       architecture: amd64
       tag: '{{ source "digest" }}'
 
@@ -26,7 +26,7 @@ targets:
     scmid: default
     sourceid: digest
     transformers:
-      - addprefix: 'registry.suse.com/bci/bci-base:'
+      - addprefix: '{{ .image.bci.name }}:'
     spec:
       file: 'Dockerfile'
       instruction:
@@ -64,4 +64,88 @@ actions:
         # TODO: use strategy `auto` when automerge and rulesets are applied
         strategy: client
         after: 0s
+      mergemethod: squash
+
+---
+name: 'Update BCI base image tag'
+
+sources:
+  tag:
+    name: Get latest BCI base image tag
+    kind: dockerimage
+    spec:
+      image: '{{ .image.bci.name }}'
+      versionfilter:
+        kind: regex
+        pattern: '^\d+\.\d+$'
+  digest:
+    name: Get latest BCI base image digest
+    kind: dockerdigest
+    dependson:
+      - tag
+    spec:
+      image: '{{ .image.bci.name }}'
+      tag: '{{ source "tag" }}'
+
+conditions:
+  image:
+    name: Check BCI base image exists
+    kind: dockerimage
+    sourceid: digest
+    spec:
+      image: '{{ .image.bci.name }}'
+      architecture: amd64
+      tag: '{{ source "digest" }}'
+
+targets:
+  dockerfile:
+    name: 'Update BCI base image digest'
+    kind: dockerfile
+    scmid: default
+    sourceid: digest
+    transformers:
+      - addprefix: '{{ .image.bci.name }}:'
+    spec:
+      file: 'Dockerfile'
+      instruction:
+        keyword: 'ARG'
+        matcher: 'BCI_IMAGE'
+  updatecli:
+    name: 'Update BCI base image tag'
+    kind: yaml
+    scmid: default
+    sourceid: tag
+    spec:
+      file: 'updatecli/values.yaml'
+      key: '$.image.bci.tag'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.user }}'
+      email: '{{ .github.email }}'
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "UPDATECLI_GITHUB_REPO" }}'
+      branch: '{{ requiredEnv "UPDATECLI_GITHUB_BRANCH" }}'
+
+actions:
+  default:
+    title: 'Update BCI base image tag'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      description:
+        <h3>Update BCI base image tag</h3>
+        <ul>
+          <li>{{ .image.bci.name }}:{{ source "tag" }}</li>
+        </ul>
+      labels:
+        - chore
+        - skip-changelog
+        - status/auto-created
+      merge:
+        strategy: manual
       mergemethod: squash

--- a/updatecli/updatecli.d/update-bci-base.yaml
+++ b/updatecli/updatecli.d/update-bci-base.yaml
@@ -1,0 +1,63 @@
+---
+name: 'Update BCI base version'
+
+sources:
+  digest:
+    name: Get latest BCI base image digest
+    kind: dockerdigest
+    spec:
+      image: 'registry.suse.com/bci/bci-base'
+      tag: 'latest'
+
+conditions:
+  image:
+    name: Check BCI base image exists
+    kind: dockerimage
+    sourceid: digest
+    spec:
+      image: registry.suse.com/bci/bci-base
+      architecture: amd64
+      tag: '{{ source "digest" }}'
+
+targets:
+  dockerfile:
+    name: 'Update BCI base image digest'
+    kind: dockerfile
+    scmid: default
+    sourceid: digest
+    transformers:
+      - addprefix: 'registry.suse.com/bci/bci-base:'
+    spec:
+      file: 'Dockerfile'
+      instruction:
+        keyword: 'ARG'
+        matcher: 'BCI_IMAGE'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.user }}'
+      email: '{{ .github.email }}'
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "UPDATECLI_GITHUB_REPO" }}'
+      branch: '{{ requiredEnv "UPDATECLI_GITHUB_BRANCH" }}'
+
+actions:
+  default:
+    title: 'Update BCI base image digest'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      description:
+        <h3>Update BCI base image digest</h3>
+        <ul>
+          <li>{{ source "digest" }}</li>
+        </ul>
+      labels:
+        - chore
+        - skip-changelog
+        - status/auto-created

--- a/updatecli/updatecli.d/update-bci-base.yaml
+++ b/updatecli/updatecli.d/update-bci-base.yaml
@@ -51,7 +51,6 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      automerge: false
       description:
         <h3>Update BCI base image digest</h3>
         <ul>
@@ -61,3 +60,8 @@ actions:
         - chore
         - skip-changelog
         - status/auto-created
+      merge:
+        # TODO: use strategy `auto` when automerge and rulesets are applied
+        strategy: client
+        after: 0s
+      mergemethod: squash

--- a/updatecli/updatecli.d/update-bci-base.yaml
+++ b/updatecli/updatecli.d/update-bci-base.yaml
@@ -2,12 +2,32 @@
 name: 'Update BCI base image digest'
 
 sources:
+  current_digest:
+    name: Get current BCI base image digest from Dockerfile
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: BCI_IMAGE
+
+  subtag:
+    name: Get latest BCI base image subtag for configured stream
+    kind: dockerimage
+    spec:
+      image: '{{ .image.bci.name }}'
+      versionfilter:
+        kind: regex
+        pattern: '^{{ .image.bci.tag }}-[0-9]+\.[0-9]+$'
+
   digest:
     name: Get latest BCI base image digest
     kind: dockerdigest
+    dependson:
+      - subtag
     spec:
       image: '{{ .image.bci.name }}'
-      tag: '{{ .image.bci.tag }}'
+      tag: '{{ source "subtag" }}'
 
 conditions:
   image:
@@ -18,6 +38,12 @@ conditions:
       image: '{{ .image.bci.name }}'
       architecture: amd64
       tag: '{{ source "digest" }}'
+  cve_gate:
+    name: Update only if current digest has CVEs and candidate has fewer CVEs
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: './updatecli/scripts/should-update-bci-digest.sh "{{ source "current_digest" }}" "{{ .image.bci.name }}:{{ source "digest" }}" "{{ source "subtag" }}"'
 
 targets:
   dockerfile:
@@ -54,6 +80,7 @@ actions:
       description:
         <h3>Update BCI base image digest</h3>
         <ul>
+          <li>{{ .image.bci.name }}:{{ source "subtag" }}</li>
           <li>{{ source "digest" }}</li>
         </ul>
       labels:

--- a/updatecli/updatecli.d/update-upstream.yaml
+++ b/updatecli/updatecli.d/update-upstream.yaml
@@ -59,10 +59,12 @@ actions:
   default:
     title: 'Bump to upstream version {{ source "tag" }}'
     kind: github/pullrequest
+    scmid: default
     spec:
-      automerge: false
       labels:
         - chore
         - skip-changelog
         - status/auto-created
-    scmid: default
+      merge:
+        strategy: manual
+      mergemethod: squash

--- a/updatecli/updatecli.d/updatebuildbase.yaml
+++ b/updatecli/updatecli.d/updatebuildbase.yaml
@@ -74,11 +74,13 @@ actions:
     default:
         title: 'Bump build base version to {{ source "latest_patch" }}'
         kind: github/pullrequest
+        scmid: default
         spec:
-            automerge: false
             labels:
                 - chore
                 - skip-changelog
                 - status/auto-created
-        scmid: default
+            merge:
+                strategy: manual
+            mergemethod: squash
 

--- a/updatecli/updatecli.d/updatek3sroot.yaml
+++ b/updatecli/updatecli.d/updatek3sroot.yaml
@@ -53,11 +53,12 @@ actions:
     default:
         title: 'Bump K3s-root version to {{ source "k3sroot" }}'
         kind: github/pullrequest
+        scmid: default
         spec:
-            automerge: false
             labels:
                 - chore
                 - skip-changelog
                 - status/auto-created
-        scmid: default
-
+            merge:
+                strategy: manual
+            mergemethod: squash

--- a/updatecli/updatecli.d/updateplugins.yaml
+++ b/updatecli/updatecli.d/updateplugins.yaml
@@ -45,11 +45,12 @@ actions:
     default:
         title: 'Bump cniplugins version to {{ source "cniplugins" }}'
         kind: github/pullrequest
+        scmid: default
         spec:
-            automerge: false
             labels:
                 - chore
                 - skip-changelog
                 - status/auto-created
-        scmid: default
-
+            merge:
+                strategy: manual
+            mergemethod: squash

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -3,6 +3,10 @@ github:
   email: "41898282+github-actions[bot]@users.noreply.github.com"
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
+image:
+  bci:
+    name: registry.suse.com/bci/bci-base
+    tag: "15.7"
 scm:
   default:
     owner: rancher


### PR DESCRIPTION
Updatecli automation for BCI image bumps.

1. Auto-merge when new image digest available (_**no review required**_)
https://github.com/mgfritch/image-build-calico/pull/24

2. Pin to a new versioned tag when available (_**review required**_)
https://github.com/mgfritch/image-build-calico/pull/25

