### PR TITLE
Drop libpcap1 runtime dependency to reduce CVE footprint

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -10,7 +10,6 @@ libnetfilter_conntrack3
 libnetfilter_cthelper0
 libnetfilter_cttimeout1
 libnetfilter_queue1
-libpcap1
 net-tools
 procps
 which


### PR DESCRIPTION
## Summary

Removes `libpcap1` from `packages.txt` to shrink the runtime image's attack surface / future CVE exposure. Both trivy and grype currently report **0 known CVEs** for bci-base (SLES 15.7), so this is about reducing future exposure and attack surface rather than fixing current findings.

## Why

`libpcap1` hard-requires `libibverbs.so.1`, which transitively drags an entire RDMA/InfiniBand + systemd stack into the final image:

```
libpcap1 → libibverbs → rdma-core → udev → systemd → dbus
```

Reproducing the final image's package operations on top of `bci-base` and diffing with/without `libpcap1` shows dropping it eliminates **33 packages (~40 MB)**, including classic CVE-bearing components a CNI pod doesn't need:

- `systemd` (13.9 MB), `udev` (12.3 MB), `dbus`
- RDMA driver stack: `rdma-core`, `libibverbs`, `libmlx4-1`, `libmlx5-1`, `libhns1`, `libefa1`, `libmana1`
- `libcryptsetup`, `libseccomp`, `libapparmor`, `kbd`, `libexpat1`, and more

## Safety verification

- `libpcap` is only a **build-time** dependency (`libpcap-dev` in the builder stage). The Calico binaries are statically linked (`go-assert-static`), and `CGO_LDFLAGS` links `-lbpf -lelf -lz -lzstd` with **no `-lpcap`** — so runtime `libpcap1` is unused.
- All remaining required `packages.txt` entries still resolve (the `rpm -q` verification step in the Dockerfile passes).
- `kmod`/`modprobe` still work — `libkmod2` was only an orphan pulled in by systemd (`rpm -q --whatrequires libkmod2` returns nothing).

## Residual risk

This was validated by replicating the package layer on bci-base, not a full end-to-end image build. Recommend confirming a normal CI image build + runtime smoke test (calico-node, calicoctl, bird, bpftool) before merge — the one thing not fully ruled out is a prebuilt binary dlopen-ing libpcap at runtime, which is unlikely for these components.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>