### PR TITLE
Override golang.org/x/text@v0.39.0 to fix CVE-2026-56852

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN git clone --depth=1 https://github.com/projectcalico/calico.git $GOPATH/src/
 WORKDIR $GOPATH/src/github.com/projectcalico/calico
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 RUN sed -n 's/^LIBBPF_VERSION=//p' metadata.mk > /tmp/libbpf_version
 RUN git clone https://github.com/libbpf/libbpf.git $GOPATH/src/github.com/projectcalico/calico/felix/bpf-gpl/libbpf
 WORKDIR $GOPATH/src/github.com/projectcalico/calico/felix/bpf-gpl/libbpf

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,3 @@
+# golang.org/x/text: CVE-2026-56852 (infinite loop on invalid input).
+# Drop once upstream requires golang.org/x/text >= v0.39.0.
+-replace golang.org/x/text=golang.org/x/text@v0.39.0


### PR DESCRIPTION
## What this does

Resolves the fixable Go vulnerabilities reported by Trivy against `rancher/hardened-calico:v3.32.1-build20260709` in the binaries built from the `github.com/projectcalico/calico` source (calicoctl, calico, calico-ipam, install, calico-node, kube-controllers):

| Library | Vulnerability | Installed | Fixed |
| --- | --- | --- | --- |
| `golang.org/x/text` | CVE-2026-56852 — infinite loop on invalid input in `golang.org/x/text` | v0.38.0 | v0.39.0 |

### Changes
This repo did not yet have a `go-mod-overrides` mechanism, so this PR introduces it:
- Add a `go-mod-overrides` file overriding `golang.org/x/text` to `v0.39.0`.
- Wire it into the Dockerfile via `go-mod-overrides.sh` (the standard tool provided by `rancher/hardened-build-base`, used by the other `image-build-*` repos), applied to the `projectcalico/calico` module in the `builder` stage so all derived build stages inherit it.

This override can be dropped once upstream calico requires `golang.org/x/text >= v0.39.0`.

### Not addressed here
- **`golang.org/x/crypto` GO-2026-5932** (unmaintained `openpgp` package) — no fixed version available, so it cannot be resolved via a module override.
- **`golang.org/x/net` / `golang.org/x/sys` findings** (in `dhcp`, `bandwidth`, `bond`, and the other `opt/cni/bin/*` plugins) — those binaries are **not built here**; they are copied from the `rancher/hardened-cni-plugins` image (`COPY --from=cni`). They are addressed in rancher/image-build-cni-plugins#204 and will clear once that merges and the `CNI_IMAGE_VERSION` ARG here is bumped to the rebuilt image.
- **SLES OS package findings** (`glibc` SUSE-SU-2026:3030-1, `krb5` SUSE-SU-2026:2848-1) — resolved by a base-image rebuild with updated packages, not via `go-mod-overrides`.

Follows the same approach as rancher/image-build-dns-nodecache#188.