### PR TITLE
Migrate from bci-base to bci-minimal for final container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 ARG ARCH=${TARGETARCH}
-ARG BCI_IMAGE=registry.suse.com/bci/bci-base:16.0
+ARG BCI_BUILD_IMAGE=registry.suse.com/bci/bci-base:16.0
+ARG BCI_RUNTIME_IMAGE=registry.suse.com/bci/bci-minimal:16.0
 ARG GO_IMAGE=rancher/hardened-build-base:v1.25.12b1
 ARG CNI_IMAGE_VERSION=v1.9.1-build20260717
 ARG CNI_IMAGE=rancher/hardened-cni-plugins:${CNI_IMAGE_VERSION}
 ARG GOEXPERIMENT=boringcrypto
 
-FROM ${BCI_IMAGE} AS bci
+FROM ${BCI_BUILD_IMAGE} AS bci
+FROM ${BCI_RUNTIME_IMAGE} AS runtime_rootfs
 FROM ${CNI_IMAGE} AS cni
 FROM ${GO_IMAGE} AS builder
 # setup required packages
@@ -150,7 +152,7 @@ RUN install -D -s bin/check-status /usr/local/bin/
 
 ### BEGIN RUNIT ###
 # We need to build runit because there aren't any rpms for it in CentOS or BCI repositories.
-FROM ${BCI_IMAGE} AS runit
+FROM bci AS runit
 ARG RUNIT_VER=2.3.1
 # Install build dependencies and security updates.
 # RUN yum install -y rpm-build yum-utils make && \
@@ -215,12 +217,18 @@ COPY --from=runit /opt/local/command/                /usr/sbin/
 FROM calico_rootfs_overlay_${ARCH} AS calico_rootfs_overlay
 
 # Build the final container image
-FROM bci AS container_image
+FROM bci AS runtime_packages
 
-# Install required packages
+# Install required packages into the minimal runtime filesystem.
+COPY --from=runtime_rootfs / /rootfs
+COPY --from=bci /etc/zypp/repos.d/ /rootfs/etc/zypp/repos.d/
 COPY packages.txt /tmp/
-RUN zypper install -y $(sed 's/#.*//' /tmp/packages.txt)
-RUN zypper update -y
+RUN zypper --gpg-auto-import-keys --root /rootfs install -y $(sed 's/#.*//' /tmp/packages.txt)
+RUN zypper --gpg-auto-import-keys --root /rootfs update -y && \
+    rm -rf /rootfs/etc/zypp /rootfs/var/cache/zypp
+
+FROM runtime_rootfs AS container_image
+COPY --from=runtime_packages /rootfs/ /
 
 # Copy the calico binaries
 COPY --from=calico_rootfs_overlay / /
@@ -229,23 +237,8 @@ RUN set -x && \
     test -e /opt/cni/bin/install && \
     ln -vs /opt/cni/bin/install /install-cni
 
-# Lock required packages to ensure they're not removed accidentally
-RUN zypper addlock $(sed 's/#.*//' /tmp/packages.txt)
-
-# Trim unnessary packages from the container image
-RUN zypper -n clean -a
-RUN zypper addlock libaugeas0 libsolv-tools-base libxml2-2
-RUN zypper rm --clean-deps --no-confirm \
-    gpg2 \
-    libcurl4 \
-    libsqlite3-0 \
-    libssh4 \
-    libzypp \
-    openssl \
-    tar
-RUN rpm -e libaugeas0 libsolv-tools-base libxml2-2
-
 # Verify required packages
+COPY packages.txt /tmp/
 RUN rpm -q $(sed 's/#.*//' /tmp/packages.txt)
 
 # Clean-up

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,6 @@ log:
 	@echo "REPO=$(REPO)"
 	@echo "REGISTRY_IMAGE=$(REGISTRY_IMAGE)"
 	@echo "METADATA_FILE=$(METADATA_FILE)"
-	@echo "PKG=$(PKG)"
-	@echo "SRC=$(SRC)"
 	@echo "BUILD_META=$(BUILD_META)"
 	@echo "UNAME_M=$(UNAME_M)"
 	@echo "META_LABELS=$(META_LABELS)"


### PR DESCRIPTION
# Replace BCI Base vs with BCI Minimal

`bci-base` remains the build/package stage. It runs Zypper against a rootfs copied from `bci-minimal`; repository metadata and caches are removed before that rootfs becomes the final image. This preserves RPM dependency resolution without publishing Zypper.

TLDR: Instead of trying to remove packages from full bci-base, we add packages we need to bci-minimal 

## Validation
Compared published `rancher/hardened-calico:v3.32.1-build20260720` with a local amd64 image rebuilt using `bci-minimal` as the runtime base.

### Measured reduction

| Metric | Base | Minimal | Change |
|---|---:|---:|---:|
| Image size | 267.3 MB | 236.1 MB | -11.7% |
| RPM records | 184 | 147 | -20.1% |
| Shared libraries | 281 | 261 | -7.1% |
| Regular files | 4,995 | 3,680 | -26.3% |

34 distinct RPM names were removed; two were added. Removed packages include FIPS, p11-kit, timezone, LDAP, Brotli, Boost, locale, and release metadata.

Locally tested, the candidate built successfully. RPM checks and smoke tests passed for Calico, BIRD, bpftool, runit, and required network tools (existence and --help check). 

## Additional Note

This does not move to BCI 16.0 as there are additional issues around difference between the two (lack of xargs in minimal now, runit legacy C code conflicts with modern available headers) The work to bump will need to come in a future PR. 

Signed-off-by: Derek Nola <derek.nola@suse.com>